### PR TITLE
Add org profile README to point to CoC

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,1 @@
+If you haven't yet, please be sure to review our [Code of Conduct](https://github.com/trussworks/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This adds an organization profile "README" that will encourage people to check out our Code of Conduct when they visit the Truss Github org page.

Visually, here is a sample of how the README will appear (with sample text):

<img width="600" alt="Screen shot of Truss' github org home page" src="https://user-images.githubusercontent.com/83984128/139508754-eebd96cc-b15b-4da3-bdd5-099dc6d4265b.png">